### PR TITLE
fix const ptr to const char

### DIFF
--- a/7/cradle.c
+++ b/7/cradle.c
@@ -13,7 +13,7 @@ char tmp[MAX_BUF];
 
 
 /* Keywords symbol table */
-const char const *KWList[] = {
+const char * const KWList[] = {
     "IF",
     "ELSE",
     "ENDIF",
@@ -29,7 +29,7 @@ char Value[MAX_BUF];     /* string token of Look */
  * If the input string matches a table entry, return the entry index, else
  * return -1.
  * *n* is the size of the table */
-int Lookup(const char const *table[], const char *string, int n)
+int Lookup(const char  * const table[], const char *string, int n)
 {
     int i;
     bool found = false;


### PR DESCRIPTION
Hi, first let me thank you for making this repo, it's been a great aid whenever I've gotten stuck when going through these tutorials.

I was going through your implementation and according to [this stack-overflow question](http://stackoverflow.com/questions/6851436/difference-between-const-char-char-const-const-char-const-string-storage) I think the array declaration should be  const char \* const.
