### PR TITLE
Fix UPCASE macro

### DIFF
--- a/1/cradle.h
+++ b/1/cradle.h
@@ -1,7 +1,7 @@
 #ifndef _CRADLE_H
 #define _CRADLE_H
 
-#define UPCASE(C) ((1<<6)| (C))
+#define UPCASE(C) (~(1<<5) & (C))
 #define MAX_BUF 100
 
 static char tmp[MAX_BUF];


### PR DESCRIPTION
Hi!

The existing UPCASE macro is actually to lowercase letters.
Please find attached test file for pull request.

Thanks.
[UPCASE_test.zip](https://github.com/lotabout/Let-s-build-a-compiler/files/914695/UPCASE_test.zip)

